### PR TITLE
fix: math lib is not linked in linux

### DIFF
--- a/bitwarden_client.go
+++ b/bitwarden_client.go
@@ -3,7 +3,7 @@ package sdk
 import (
 	"encoding/json"
 
-	"github.com/bitwarden/sdk-go/internal/cinterface"
+	"github.com/mattscamp/sdk-go/internal/cinterface"
 )
 
 type BitwardenClientInterface interface {

--- a/command_runner.go
+++ b/command_runner.go
@@ -3,7 +3,7 @@ package sdk
 import (
 	"encoding/json"
 
-	"github.com/bitwarden/sdk-go/internal/cinterface"
+	"github.com/mattscamp/sdk-go/internal/cinterface"
 )
 
 type CommandRunnerInterface interface {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/bitwarden/sdk-go
+module github.com/mattscamp/sdk-go
 
 go 1.18

--- a/internal/cinterface/bitwarden_library.go
+++ b/internal/cinterface/bitwarden_library.go
@@ -6,6 +6,7 @@ import (
 )
 
 /*
+#cgo LDFLAGS: -lm
 #cgo LDFLAGS: -lbitwarden_c
 #cgo linux,amd64 LDFLAGS: -L ./lib/linux-x64
 #cgo linux,arm64 LDFLAGS: -L ./lib/linux-arm64

--- a/internal/cinterface/bitwarden_library.go
+++ b/internal/cinterface/bitwarden_library.go
@@ -7,9 +7,8 @@ import (
 
 /*
 #cgo LDFLAGS: -lm
-#cgo LDFLAGS: -lbitwarden_c
-#cgo linux,amd64 LDFLAGS: -L ./lib/linux-x64
-#cgo linux,arm64 LDFLAGS: -L ./lib/linux-arm64
+#cgo linux,amd64 LDFLAGS: -L ./lib/linux-x64 -lm
+#cgo linux,arm64 LDFLAGS: -L ./lib/linux-arm64 -lm
 #cgo darwin,amd64 LDFLAGS: -L ./lib/darwin-x64 -framework Security -framework SystemConfiguration
 #cgo darwin,arm64 LDFLAGS: -L ./lib/darwin-arm64 -framework Security -framework SystemConfiguration
 #cgo windows,amd64 LDFLAGS: -L ./lib/windows-x64 -lbitwarden_c -ladvapi32 -lbcrypt -lcrypt32 -lcryptnet -lkernel32 -lncrypt -lntdll -luserenv -lws2_32 -lmsvcrt

--- a/internal/cinterface/bitwarden_library.go
+++ b/internal/cinterface/bitwarden_library.go
@@ -6,7 +6,7 @@ import (
 )
 
 /*
-#cgo LDFLAGS: -lm
+#cgo LDFLAGS: -lbitwarden_c
 #cgo linux,amd64 LDFLAGS: -L ./lib/linux-x64 -lm
 #cgo linux,arm64 LDFLAGS: -L ./lib/linux-arm64 -lm
 #cgo darwin,amd64 LDFLAGS: -L ./lib/darwin-x64 -framework Security -framework SystemConfiguration


### PR DESCRIPTION
The math lib is used upstream and not linked properly. This causes the below failures on linux.

```
/usr/lib/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: /home/mattc/git/sdk-go/internal/cinterface/lib/linux-x64/libbitwarden_c.a(bitwarden_c.tokio-3c56ba4e3c4aa90a.tokio.db699ad6e67f3ec9-cgu.0.rcgu.o.rcgu.o): in function `tokio::runtime::scheduler::multi_thread::worker::run':
tokio.db699ad6e67f3ec9-cgu.0:(.text._ZN5tokio7runtime9scheduler12multi_thread6worker3run17h40b487d4e81f7731E+0x692): undefined reference to `pow'
/usr/bin/ld: tokio.db699ad6e67f3ec9-cgu.0:(.text._ZN5tokio7runtime9scheduler12multi_thread6worker3run17h40b487d4e81f7731E+0xc95): undefined reference to `pow'
/usr/bin/ld: /home/mattc/git/sdk-go/internal/cinterface/lib/linux-x64/libbitwarden_c.a(bitwarden_c.num_cpus-48d8c06d94ff50f9.num_cpus.baa012fa3dfb01b7-cgu.0.rcgu.o.rcgu.o): in function `std::sys::sync::once::futex::Once::call':
num_cpus.baa012fa3dfb01b7-cgu.0:(.text.unlikely._ZN3std3sys4sync4once5futex4Once4call17h8448e83b91b21622E.llvm.16575399225377328621+0x15de): undefined reference to `ceil'
collect2: error: ld returned 1 exit status
```